### PR TITLE
Basic support for Twilio

### DIFF
--- a/lib/mote_sms.rb
+++ b/lib/mote_sms.rb
@@ -1,13 +1,8 @@
+require 'mote_sms/message'
 require 'mote_sms/transports'
+require 'mote_sms/version'
 
 module MoteSMS
-  autoload :Number,      'mote_sms/number'
-  autoload :NumberList,  'mote_sms/number_list'
-  autoload :Message,     'mote_sms/message'
-  autoload :DeliveryJob, 'mote_sms/delivery_job'
-
-  autoload :VERSION,    'mote_sms/version'
-
   # No default transport.
   @@transport = nil
   @@delayed_delivery_queue = :default

--- a/lib/mote_sms/message.rb
+++ b/lib/mote_sms/message.rb
@@ -1,5 +1,6 @@
 require 'mote_sms/number'
 require 'mote_sms/number_list'
+require 'mote_sms/delivery_job'
 
 module MoteSMS
 

--- a/lib/mote_sms/transports.rb
+++ b/lib/mote_sms/transports.rb
@@ -1,10 +1,9 @@
 module MoteSMS
-
   # All transports live within mote_sms/transports, though should be
   # available in ruby as `MoteSMS::<Some>Transport`.
-  autoload :SslTransport, 'mote_sms/transports/concerns/ssl_transport'
   autoload :TestTransport, 'mote_sms/transports/test_transport'
   autoload :MobileTechnicsTransport, 'mote_sms/transports/mobile_technics_transport'
   autoload :ActionMailerTransport, 'mote_sms/transports/action_mailer_transport'
   autoload :SwisscomTransport, 'mote_sms/transports/swisscom_transport'
+  autoload :TwilioTransport, 'mote_sms/transports/twilio_transport'
 end

--- a/lib/mote_sms/transports/twilio_transport.rb
+++ b/lib/mote_sms/transports/twilio_transport.rb
@@ -1,0 +1,41 @@
+require 'phony'
+require 'twilio-ruby'
+
+require 'mote_sms/message'
+
+module MoteSMS
+
+  # Wrapper for twilio-ruby gem.
+  class TwilioTransport
+    # Maximum recipients supported
+    MAX_RECIPIENT = 1
+
+    attr_reader :client, :from_number
+
+    def initialize(account_sid, auth_token, from_number = nil)
+      @client = Twilio::REST::Client.new(account_sid, auth_token)
+      @from_number = from_number
+    end
+
+    # Public: Delivers message using mobile technics HTTP/S API.
+    #
+    # message - The MoteSMS::Message instance to send.
+    # options - The Hash with service specific options.
+    #
+    # Returns Array with sender ids.
+    def deliver(message, options = {})
+      raise ArgumentError, "too many recipients, max. is #{MAX_RECIPIENT} (current: #{message.to.length})" if message.to.length > MAX_RECIPIENT
+
+      @client.messages.create(
+        from: (message.from || from_number).to_s,
+        to: fetch_number(message.to),
+        body: message.body)
+    end
+
+    private
+
+    def fetch_number(number_list)
+      number_list.normalized_numbers.first.to_s
+    end
+  end
+end

--- a/mote_sms.gemspec
+++ b/mote_sms.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'webmock', ['~> 1.8.0']
   gem.add_development_dependency 'actionmailer', ['>= 4.2', '< 6']
   gem.add_development_dependency 'activejob', ['>= 4.2', '< 6']
+  gem.add_development_dependency 'twilio-ruby', ['~> 4.10']
 end

--- a/spec/mote_sms/delivery_job_spec.rb
+++ b/spec/mote_sms/delivery_job_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'mote_sms'
+require 'mote_sms/delivery_job'
 
 describe MoteSMS::DeliveryJob do
   subject { described_class.new }

--- a/spec/mote_sms/transports/twilio_transport_spec.rb
+++ b/spec/mote_sms/transports/twilio_transport_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'mote_sms/transports/twilio_transport'
+
+describe MoteSMS::TwilioTransport do
+  subject { described_class.new('account', '123456') }
+
+  let(:message) {
+    MoteSMS::Message.new do
+      from '+41791110011'
+      to '+41790001122'
+      body 'Hello World'
+    end
+  }
+
+  context '#deliver' do
+    before {
+      expect(subject.client.messages).to receive(:create).with(
+        from: '41791110011',
+        to: '41790001122',
+        body: 'Hello World'
+      ) { Twilio::REST::Message.new('/SMS', subject.client) }
+    }
+
+    it 'delegates to Twilio::REST::Client#messages#create()' do
+      expect(subject.deliver message).to be_a(Twilio::REST::Message)
+    end
+  end
+end

--- a/spec/mote_sms/transports/twilio_transport_spec.rb
+++ b/spec/mote_sms/transports/twilio_transport_spec.rb
@@ -2,27 +2,43 @@ require 'spec_helper'
 require 'mote_sms/transports/twilio_transport'
 
 describe MoteSMS::TwilioTransport do
-  subject { described_class.new('account', '123456') }
+  subject { described_class.new('account', '123456', '41791110011') }
 
   let(:message) {
     MoteSMS::Message.new do
-      from '+41791110011'
       to '+41790001122'
       body 'Hello World'
     end
   }
 
+  let(:result) { Twilio::REST::Message.new('/SMS', subject.client) }
+
+  context '#initialize' do
+    it 'sets account_sid' do
+      expect(subject.client.account_sid).to eq 'account'
+    end
+  end
+
   context '#deliver' do
-    before {
+    it 'delegates to Twilio::REST::Client#messages#create()' do
       expect(subject.client.messages).to receive(:create).with(
         from: '41791110011',
         to: '41790001122',
         body: 'Hello World'
-      ) { Twilio::REST::Message.new('/SMS', subject.client) }
-    }
+      ) { result }
 
-    it 'delegates to Twilio::REST::Client#messages#create()' do
-      expect(subject.deliver message).to be_a(Twilio::REST::Message)
+      expect(subject.deliver(message)).to be_a(Twilio::REST::Message)
+    end
+
+    it 'uses the number from the message' do
+      message.from = 'OTHER'
+      expect(subject.client.messages).to receive(:create).with(
+        from: 'OTHER',
+        to: '41790001122',
+        body: 'Hello World'
+      ) { result }
+
+      expect(subject.deliver(message)).to be_a(Twilio::REST::Message)
     end
   end
 end


### PR DESCRIPTION
Simple wrapper for the [twilio-ruby][tw] gem, to be used directly as a MoteSMS transport.

[tw]: https://github.com/twilio/twilio-ruby