### PR TITLE
Transport adaptations for swisscom API

### DIFF
--- a/lib/mote_sms/transports/swisscom_transport.rb
+++ b/lib/mote_sms/transports/swisscom_transport.rb
@@ -75,11 +75,12 @@ module MoteSMS
       raise ServiceError, "too many recipients, max. is #{MAX_RECIPIENT} (current: #{message.to.length})" if message.to.length > MAX_RECIPIENT
 
       # Prepare request
-      request = Net::HTTP::Post.new('/messaging/v1/sms').tap do |request|
+      request = Net::HTTP::Post.new('/messaging/sms').tap do |request|
         request.body = post_params(message)
-        request.content_type = 'application/json; charset=utf-8'
-        request['Accept'] = 'application/json; charset=utf-8'
+        request.content_type = 'application/json'
+        request['Accept'] = 'application/json'
         request['client_id'] = api_key
+        request['SCS-Version'] = 2
       end
 
       # Log as `curl` request

--- a/spec/mote_sms/transports/http_client_spec.rb
+++ b/spec/mote_sms/transports/http_client_spec.rb
@@ -11,9 +11,9 @@ describe Transports::HttpClient do
       subject { described_class.new('https://api.swisscom.com/') }
 
       it 'makes a "successful" request, i.e. no HTTPS issues' do
-        request = Net::HTTP::Get.new('/')
+        request = Net::HTTP::Get.new('/messaging/sms')
         response = subject.request(request)
-        expect(response).to be_a Net::HTTPInternalServerError
+        expect(response).to be_a Net::HTTPUnauthorized
       end
     end
 
@@ -22,7 +22,7 @@ describe Transports::HttpClient do
 
       it 'makes a "successful" request, i.e. no HTTPS issues' do
         stub_request(:get, "https://bulk.mobile-gw.com:9012/").
-          with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby/mote_sms 1.3.11'}).
+          with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=> "Ruby/mote_sms #{MoteSMS::VERSION}"}).
           to_return(:status => 200, :body => '', :headers => {})
         request = Net::HTTP::Get.new('/')
         response = subject.request(request)

--- a/spec/mote_sms/transports/swisscom_transport_spec.rb
+++ b/spec/mote_sms/transports/swisscom_transport_spec.rb
@@ -31,7 +31,7 @@ describe MoteSMS::SwisscomTransport do
 
   context '#deliver' do
     it 'sends POST to endpoint with JSON body and Client ID' do
-      stub_request(:post, "#{endpoint}/messaging/v1/sms").with do |req|
+      stub_request(:post, "#{endpoint}/messaging/sms").with do |req|
         params = JSON.load(req.body)
         expect(params['text']).to eq 'Hello World, with äöü.'
         expect(params['to']).to eq '+41791231212'
@@ -47,19 +47,19 @@ describe MoteSMS::SwisscomTransport do
     end
 
     it 'raises exception if status code is not 201' do
-      stub_request(:post, "#{endpoint}/messaging/v1/sms").to_return(status: 500)
+      stub_request(:post, "#{endpoint}/messaging/sms").to_return(status: 500)
       expect { subject.deliver message }.to raise_error(described_class::ServiceError)
     end
 
     it 'returns truthy on success' do
-      stub_request(:post, "#{endpoint}/messaging/v1/sms").to_return(success)
+      stub_request(:post, "#{endpoint}/messaging/sms").to_return(success)
       expect(subject.deliver(message)).to be_truthy
     end
 
     it 'logs curl compatible output' do
       io = StringIO.new
       described_class.logger = Logger.new(io)
-      stub_request(:post, "#{endpoint}/messaging/v1/sms").to_return(success)
+      stub_request(:post, "#{endpoint}/messaging/sms").to_return(success)
       subject.deliver message
       io.rewind
       expect(io.read).to include('curl -XPOST \'https://api.example.com\' -d \'{')


### PR DESCRIPTION
Swisscom is switching its api from V1 to V2 on the 1st February 2019. V1 not being supported anymore since this date, thus no versioning of the client